### PR TITLE
0.25.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Please read the documents in the `docs` folder for more advanced configuration a
     - [Ready to go](#ready-to-go)
     - [Load the introductory scenario "Infinity Quest"](#load-the-introductory-scenario-infinity-quest)
     - [Loading character cards](#loading-character-cards)
+- [Configure for hosting](#configure-for-hosting)
 - [Text-to-Speech (TTS)](docs/tts.md)
 - [Visual Generation](docs/visual.md)
 - [ChromaDB (long term memory) configuration](docs/chromadb.md)
@@ -251,3 +252,17 @@ Expand the "Load" menu in the top left corner and either click on "Upload a char
 Once a character is uploaded, talemate may actually take a moment because it needs to convert it to a talemate format and will also run additional LLM prompts to generate character attributes and world state.
 
 Make sure you save the scene after the character is loaded as it can then be loaded as normal talemate scenario in the future.
+
+## Configure for hosting
+
+By default talemate is configured to run locally. If you want to host it behind a reverse proxy or on a server, you will need create some environment variables in the `talemate_frontend/.env.development.local` file
+
+Start by copying `talemate_frontend/example.env.development.local` to `talemate_frontend/.env.development.local`.
+
+Then open the file and edit the `ALLOWED_HOSTS` and  `VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL` variables.
+
+```sh
+ALLOWED_HOSTS=example.com
+# wss if behind ssl, ws if not
+VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL=wss://example.com:5050
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "talemate"
-version = "0.25.2"
+version = "0.25.3"
 description = "AI-backed roleplay and narrative tools"
 authors = ["FinalWombat"]
 license = "GNU Affero General Public License v3.0"

--- a/src/talemate/__init__.py
+++ b/src/talemate/__init__.py
@@ -2,4 +2,4 @@ from .agents import Agent
 from .client import TextGeneratorWebuiClient
 from .tale_mate import *
 
-VERSION = "0.25.2"
+VERSION = "0.25.3"

--- a/src/talemate/agents/base.py
+++ b/src/talemate/agents/base.py
@@ -221,6 +221,9 @@ class Agent(ABC):
         if callback:
             await callback()
 
+    async def setup_check(self):
+        return False
+
     async def ready_check(self, task: asyncio.Task = None):
         self.ready_check_error = None
         if task:

--- a/src/talemate/agents/visual/__init__.py
+++ b/src/talemate/agents/visual/__init__.py
@@ -199,7 +199,6 @@ class VisualBase(Agent):
 
     async def ready_check(self):
         if not self.enabled:
-            await self.setup_check()
             return
         backend = self.backend
         fn = getattr(self, f"{backend.lower()}_ready", None)

--- a/src/talemate/client/base.py
+++ b/src/talemate/client/base.py
@@ -122,6 +122,10 @@ class ClientBase:
         """
         return self.Meta().requires_prompt_template
 
+    @property
+    def max_tokens_param_name(self):
+        return "max_tokens"
+
     def set_client(self, **kwargs):
         self.client = AsyncOpenAI(base_url=self.api_url, api_key="sk-1111")
 
@@ -625,7 +629,7 @@ class ClientBase:
             is_repetition, similarity_score, matched_line = util.similarity_score(
                 response, finalized_prompt.split("\n"), similarity_threshold=80
             )
-
+            
             if not is_repetition:
                 # not a repetition, return the response
 
@@ -659,7 +663,7 @@ class ClientBase:
 
                 # then we pad the max_tokens by the pad_max_tokens amount
 
-                prompt_param["max_tokens"] += pad_max_tokens
+                prompt_param[self.max_tokens_param_name] += pad_max_tokens
 
                 # send the prompt again
                 # we use the repetition_adjustment method to further encourage
@@ -681,7 +685,7 @@ class ClientBase:
 
                 # a lot of the times the response will now contain the repetition + something new
                 # so we dedupe the response to remove the repetition on sentences level
-
+                
                 response = util.dedupe_sentences(
                     response, matched_line, similarity_threshold=85, debug=True
                 )

--- a/src/talemate/client/koboldccp.py
+++ b/src/talemate/client/koboldccp.py
@@ -69,7 +69,7 @@ class KoboldCppClient(ClientBase):
     def ensure_api_endpoint_specified(self):
         if not self.api_endpoint_specified(self.api_url):
             # url doesn't specify the api endpoint
-            # use the koboldcpp openai api
+            # use the koboldcpp united api
             self.api_url = urljoin(self.api_url.rstrip("/") + "/", "/api/v1/")
         if not self.api_url.endswith("/"):
             self.api_url += "/"
@@ -183,14 +183,19 @@ class KoboldCppClient(ClientBase):
         adjusts temperature and repetition_penalty
         by random values using the base value as a center
         """
+        
+        if self.is_openai:
+            rep_pen_key = "presence_penalty"
+        else:
+            rep_pen_key = "rep_pen"
 
         temp = prompt_config["temperature"]
-        rep_pen = prompt_config["rep_pen"]
+        rep_pen = prompt_config[rep_pen_key]
 
         min_offset = offset * 0.3
 
         prompt_config["temperature"] = random.uniform(temp + min_offset, temp + offset)
-        prompt_config["rep_pen"] = random.uniform(
+        prompt_config[rep_pen_key] = random.uniform(
             rep_pen + min_offset * 0.3, rep_pen + offset * 0.3
         )
 

--- a/src/talemate/client/koboldccp.py
+++ b/src/talemate/client/koboldccp.py
@@ -271,6 +271,9 @@ class KoboldCppClient(ClientBase):
         if the koboldcpp server has a SD model available
         """
         
+        if not self.connected:
+            return False
+        
         sd_models_url = urljoin(self.url, "/sdapi/v1/sd-models")
         
         async with httpx.AsyncClient() as client:

--- a/src/talemate/client/koboldccp.py
+++ b/src/talemate/client/koboldccp.py
@@ -64,6 +64,13 @@ class KoboldCppClient(ClientBase):
             # join /api/v1/generate
             return urljoin(self.api_url, "generate")
 
+    @property
+    def max_tokens_param_name(self):
+        if self.is_openai:
+            return "max_tokens"
+        else:
+            return "max_length"
+
     def api_endpoint_specified(self, url: str) -> bool:
         return "/v1" in self.api_url
 
@@ -184,13 +191,16 @@ class KoboldCppClient(ClientBase):
         adjusts temperature and repetition_penalty
         by random values using the base value as a center
         """
-        
-        if self.is_openai:
-            rep_pen_key = "presence_penalty"
-        else:
-            rep_pen_key = "rep_pen"
 
         temp = prompt_config["temperature"]
+        
+        if "rep_pen" in prompt_config:
+            rep_pen_key = "rep_pen"
+        elif "frequency_penalty" in prompt_config:
+            rep_pen_key = "frequency_penalty"
+        else:
+            rep_pen_key = "repetition_penalty"
+        
         rep_pen = prompt_config[rep_pen_key]
 
         min_offset = offset * 0.3
@@ -199,7 +209,7 @@ class KoboldCppClient(ClientBase):
         prompt_config[rep_pen_key] = random.uniform(
             rep_pen + min_offset * 0.3, rep_pen + offset * 0.3
         )
-
+        
     def reconfigure(self, **kwargs):
         if "api_key" in kwargs:
             self.api_key = kwargs.pop("api_key")

--- a/src/talemate/client/koboldccp.py
+++ b/src/talemate/client/koboldccp.py
@@ -13,6 +13,7 @@ log = structlog.get_logger("talemate.client.koboldcpp")
 
 
 class KoboldCppClientDefaults(Defaults):
+    api_url: str = "http://localhost:5001"
     api_key: str = ""
 
 

--- a/src/talemate/client/koboldccp.py
+++ b/src/talemate/client/koboldccp.py
@@ -274,9 +274,14 @@ class KoboldCppClient(ClientBase):
         sd_models_url = urljoin(self.url, "/sdapi/v1/sd-models")
         
         async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url=sd_models_url, timeout=2
-            )
+            
+            try:
+                response = await client.get(
+                   url=sd_models_url, timeout=2
+                )
+            except Exception as exc:
+                log.error(f"Failed to fetch sd models from {sd_models_url}", exc=exc)
+                return False
             
             if response.status_code != 200:
                 return False

--- a/src/talemate/client/openai.py
+++ b/src/talemate/client/openai.py
@@ -28,12 +28,14 @@ SUPPORTED_MODELS = [
     "gpt-4-turbo-preview",
     "gpt-4-turbo-2024-04-09",
     "gpt-4-turbo",
+    "gpt-4o-2024-05-13",
+    "gpt-4o",
 ]
 
+# any model starting with gpt-4- is assumed to support 'json_object'
+# for others we need to explicitly state the model name
 JSON_OBJECT_RESPONSE_MODELS = [
-    "gpt-4-1106-preview",
-    "gpt-4-0125-preview",
-    "gpt-4-turbo-preview",
+    "gpt-4o",
     "gpt-3.5-turbo-0125",
 ]
 
@@ -92,7 +94,7 @@ def num_tokens_from_messages(messages: list[dict], model: str = "gpt-3.5-turbo-0
 
 class Defaults(pydantic.BaseModel):
     max_token_length: int = 16384
-    model: str = "gpt-4-turbo"
+    model: str = "gpt-4o"
 
 
 @register()
@@ -115,7 +117,7 @@ class OpenAIClient(ClientBase):
         requires_prompt_template: bool = False
         defaults: Defaults = Defaults()
 
-    def __init__(self, model="gpt-4-turbo", **kwargs):
+    def __init__(self, model="gpt-4o", **kwargs):
         self.model_name = model
         self.api_key_status = None
         self.config = load_config()

--- a/src/talemate/client/openai.py
+++ b/src/talemate/client/openai.py
@@ -94,7 +94,7 @@ def num_tokens_from_messages(messages: list[dict], model: str = "gpt-3.5-turbo-0
 
 class Defaults(pydantic.BaseModel):
     max_token_length: int = 16384
-    model: str = "gpt-4o"
+    model: str = "gpt-4-turbo"
 
 
 @register()
@@ -117,7 +117,7 @@ class OpenAIClient(ClientBase):
         requires_prompt_template: bool = False
         defaults: Defaults = Defaults()
 
-    def __init__(self, model="gpt-4o", **kwargs):
+    def __init__(self, model="gpt-4-turbo", **kwargs):
         self.model_name = model
         self.api_key_status = None
         self.config = load_config()

--- a/src/talemate/instance.py
+++ b/src/talemate/instance.py
@@ -187,3 +187,5 @@ async def agent_ready_checks():
     for agent in AGENTS.values():
         if agent and agent.enabled:
             await agent.ready_check()
+        elif agent and not agent.enabled:
+            await agent.setup_check()

--- a/src/talemate/tale_mate.py
+++ b/src/talemate/tale_mate.py
@@ -2123,7 +2123,7 @@ class Scene(Emitter):
 
     async def add_to_recent_scenes(self):
         log.debug("add_to_recent_scenes", filename=self.filename)
-        config = Config(**self.config)
+        config = load_config(as_model=True)
         config.recent_scenes.push(self)
         config.save()
 

--- a/talemate_frontend/example.env.development.local
+++ b/talemate_frontend/example.env.development.local
@@ -1,0 +1,3 @@
+ALLOWED_HOSTS=example.com
+# wss if behind ssl, ws if not
+VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL=wss://example.com:5050

--- a/talemate_frontend/package-lock.json
+++ b/talemate_frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "talemate_frontend",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "talemate_frontend",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.5",
         "@codemirror/theme-one-dark": "^6.1.2",

--- a/talemate_frontend/package.json
+++ b/talemate_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talemate_frontend",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/talemate_frontend/src/components/TalemateApp.vue
+++ b/talemate_frontend/src/components/TalemateApp.vue
@@ -303,9 +303,11 @@ export default {
 
       this.connecting = true;
       let currentUrl = new URL(window.location.href);
-      console.log(currentUrl);
+      let websocketUrl = process.env.VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL || `ws://${currentUrl.hostname}:5050/ws`;
 
-      this.websocket = new WebSocket(`ws://${currentUrl.hostname}:5050/ws`);
+      console.log("urls", { websocketUrl, currentUrl }, {env : process.env});
+
+      this.websocket = new WebSocket(websocketUrl);
       console.log("Websocket connecting ...")
       this.websocket.onmessage = this.handleMessage;
       this.websocket.onopen = () => {

--- a/talemate_frontend/vue.config.js
+++ b/talemate_frontend/vue.config.js
@@ -1,4 +1,16 @@
 const { defineConfig } = require('@vue/cli-service')
+
+const ALLOWED_HOSTS = process.env.ALLOWED_HOSTS || "all"
+const VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL = process.env.VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL || null
+
+// if ALLOWED_HOSTS is set and has , then split it
+if (ALLOWED_HOSTS !== "all") {
+  ALLOWED_HOSTS = ALLOWED_HOSTS.split(",")
+}
+
+console.log("ALLOWED_HOSTS", ALLOWED_HOSTS)
+console.log("VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL", VUE_APP_TALEMATE_BACKEND_WEBSOCKET_URL)
+
 module.exports = defineConfig({
   transpileDependencies: true,
 
@@ -9,7 +21,7 @@ module.exports = defineConfig({
   },
 
   devServer: {
-    allowedHosts: "all",
+    allowedHosts: ALLOWED_HOSTS,
     client: {
       overlay: {
         warnings: false,


### PR DESCRIPTION
fixes #112 - env var config for frontend serve
fixes #111 - openai gpt-4o added
fixes #109 - koboldcpp bug fixes / enhancements
  - fix `rep_pen` and `max_tokens` errors
  - auto configure visual agent to kcpp automatic1111 if available (`Automatic Setup` option needs to be turned on in agent)
  - use tokencount endpoint for accurate token counts
  - default port changed to 5001
  
  ### Untracked changes
  
  - fixes issues where saving a new scene could cause recent config changes to revert