### PR TITLE
Add ruff and mypy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,11 @@ scenes/
 !scenes/infinity-quest/assets/
 !scenes/infinity-quest/infinity-quest.json
 tts_voice_samples/*.wav
-third-party-docs/
+third-party-docs/.serena/
+
+# ai
+.serena/
+.claude/
+CLAUDE.md
+.roo/
+.cline/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,85 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 88
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+check_untyped_defs = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+pretty = true
+show_error_codes = true
+show_error_context = true
+show_column_numbers = true
+exclude = '''(?x)(
+    \.git
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+    | talemate_env
+    | talemate_frontend
+)'''
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+exclude = [
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "talemate_env",
+    "talemate_frontend",
+    "__pycache__",
+]
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "B",     # flake8-bugbear
+    "C4",    # flake8-comprehensions
+    "UP",    # pyupgrade
+    "ARG",   # flake8-unused-arguments
+    "SIM",   # flake8-simplify
+    "C90",   # McCabe complexity
+    "N",     # pep8-naming
+    "RUF",   # Ruff-specific rules
+]
+ignore = [
+    "E501",  # line too long (handled by black)
+    "B008",  # do not perform function calls in argument defaults
+    "B027",  # empty method in abstract base class
+    "SIM108", # use ternary operator (can hurt readability)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]  # imported but unused
+"tests/*" = ["ARG"]  # unused arguments in tests
+
+[tool.ruff.lint.isort]
+known-first-party = ["talemate"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[dependency-groups]
+dev = [
+    "mypy>=1.16.1",
+]


### PR DESCRIPTION
## Summary
- Add ruff linting configuration to standardize code quality
- Add mypy type checking configuration with relaxed initial rules for gradual adoption
- Update .gitignore to exclude development tool directories

## Changes
- Updated `pyproject.toml` with ruff and mypy configurations
- Added mypy to dev dependencies
- Updated `.gitignore` to exclude .serena, .claude, CLAUDE.md, .roo, and .cline directories

## Notes
This PR only adds the configuration without applying any code changes. The actual linting fixes can be applied in separate PRs to keep the changes reviewable.