### PR TITLE
Added Stop Token Injection into Conversation Agent, so that it can be disabled for LLMs, that use character names during thinking

### DIFF
--- a/src/talemate/agents/conversation/__init__.py
+++ b/src/talemate/agents/conversation/__init__.py
@@ -148,8 +148,8 @@ class ConversationAgent(MemoryRAGMixin, Agent):
                         label="Include character names in stop tokens",
                         value=True,
                         description="Some models may generate the names of other characters during internal reasoning, which can cause generation to stop (for example, GLM 4.7 Flash). If you experience sudden generation stops, try disabling this option.",
-                        ),
-                    },
+                    ),
+                },
             ),
             "content": AgentAction(
                 enabled=True,
@@ -239,10 +239,14 @@ class ConversationAgent(MemoryRAGMixin, Agent):
     @property
     def generation_settings_actor_instructions(self):
         return self.actions["generation_override"].config["actor_instructions"].value
-    
+
     @property
     def inject_character_names_into_stop(self) -> bool:
-        return self.actions["generation_override"].config["inject_character_names_into_stop"].value
+        return (
+            self.actions["generation_override"]
+            .config["inject_character_names_into_stop"]
+            .value
+        )
 
     @property
     def generation_settings_actor_instructions_offset(self):
@@ -516,6 +520,9 @@ class ConversationAgent(MemoryRAGMixin, Agent):
     def inject_prompt_paramters(
         self, prompt_param: dict, kind: str, agent_function_name: str
     ):
-        if prompt_param.get("extra_stopping_strings") is None or not self.inject_character_names_into_stop:
+        if (
+            prompt_param.get("extra_stopping_strings") is None
+            or not self.inject_character_names_into_stop
+        ):
             prompt_param["extra_stopping_strings"] = []
         prompt_param["extra_stopping_strings"] += ["#"]


### PR DESCRIPTION
Models like GLM 4.7 Flash (and other ones, that do analysis) often generate structured lists in their thinking process with information about characters. 
When they start to list out the other characters, the generation ends and returns the in progress analysis, as all character names are included in the stop tokens. But as other models need this guard to prevent overgeneration, i have added this switch to Conversation Generation. 