### PR TITLE
0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 _Auto-generated. Do not edit by hand._
 
+## 0.37.1
+
+### Bug Fixes
+
+**Scene History**
+
+- Fixed a crash when generating dialogue in long scenes that combine layered history with pre-established history entries. The scene could become unplayable until its layered history was manually edited.
+
 ## 0.37.0
 
 ### Upgrade Notes

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,6 @@
+0.37.1:
+  fixes:
+  - "Scene History: Fixed a crash when generating dialogue in long scenes that combine layered history with pre-established (static) history entries. The affected scene could become unplayable until its layered history was manually edited."
 0.37.0:
   features:
   - "System Prompt Template Variable: Added {{ system_prompt }} template variable for system prompt overrides. Use it to include the default system prompt within a custom override, at both the app and client level."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "talemate"
-version = "0.37.0"
+version = "0.37.1"
 description = "AI-backed roleplay and narrative tools"
 authors = [{name = "VeguAITools"}]
 license = {text = "GNU Affero General Public License v3.0"}

--- a/src/talemate/agents/summarize/context_history.py
+++ b/src/talemate/agents/summarize/context_history.py
@@ -872,13 +872,40 @@ class ContextHistoryMixin:
 
         if has_layered:
             num_layers = len(scene.layered_history)
+
+            # Layer 0's start/end index into the full archived_history, but
+            # the archived level below only contains summary entries. Static
+            # entries (no "end" — pre-established notes) are always contiguous
+            # at the front of archived_history, so a single constant offset
+            # realigns layer-0 indices with the archived level.
+            archived_offset = next(
+                (
+                    idx
+                    for idx, e in enumerate(scene.archived_history)
+                    if e.get("end") is not None
+                ),
+                0,
+            )
+
             for i in range(num_layers - 1, -1, -1):
                 layer = scene.layered_history[i]
                 if not layer:
                     continue
+
+                entries = layer
+                if i == 0 and archived_offset:
+                    entries = [
+                        {
+                            **e,
+                            "start": max(0, e.get("start", 0) - archived_offset),
+                            "end": e.get("end", 0) - archived_offset,
+                        }
+                        for e in layer
+                    ]
+
                 formatted: list[str] = []
                 tokens: list[int] = []
-                for entry in layer:
+                for entry in entries:
                     text, _ = self._context_history_format_layered_entry(
                         entry, scene.ts
                     )
@@ -886,7 +913,7 @@ class ContextHistoryMixin:
                     tokens.append(count_tokens(text))
                 levels.append(
                     _BestFitLevel(
-                        entries=layer,
+                        entries=entries,
                         formatted=formatted,
                         tokens=tokens,
                         type="layer",

--- a/src/talemate/version.py
+++ b/src/talemate/version.py
@@ -1,3 +1,3 @@
 __all__ = ["VERSION"]
 
-VERSION = "0.37.0"
+VERSION = "0.37.1"

--- a/talemate_frontend/package.json
+++ b/talemate_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talemate_frontend",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/talemate_frontend/src/components/WhatsNew.vue
+++ b/talemate_frontend/src/components/WhatsNew.vue
@@ -95,8 +95,20 @@ export default {
     data() {
         return {
             dialog: false,
-            selected: "0.37.0",
+            selected: "0.37.1",
             whatsNew: [
+                {
+                    version: '0.37.1',
+                    items: [
+                        {
+                            title: "Bugfix release",
+                            description: "Fixes a crash affecting some long scenes that use layered history.",
+                            items: [
+                                "Fixed a crash when generating dialogue in long scenes that combine layered history with pre-established history entries. The scene could become unplayable until its layered history was manually edited."
+                            ]
+                        }
+                    ]
+                },
                 {
                     "version": "0.37.0",
                     "items": [

--- a/talemate_frontend/src/constants/version.js
+++ b/talemate_frontend/src/constants/version.js
@@ -1,4 +1,4 @@
-export const FRONTEND_VERSION = "0.37.0";
+export const FRONTEND_VERSION = "0.37.1";
 
 export function versionsMatch(backendVersion) {
   return FRONTEND_VERSION === backendVersion;

--- a/uv.lock
+++ b/uv.lock
@@ -5694,7 +5694,7 @@ wheels = [
 
 [[package]]
 name = "talemate"
-version = "0.37.0"
+version = "0.37.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION

Fixes a crash when generating dialogue in long scenes that combine layered history with pre-established history entries. The scene could become unplayable until its layered history was manually edited.